### PR TITLE
Battle cafe spins

### DIFF
--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -390,6 +390,7 @@ class Game {
                         timeout: 3e4,
                     });
                 }
+                BattleCafeController.spinsLeft(BattleCafeController.spinsPerDay());
 
                 DayOfWeekRequirement.date(now.getDay());
             }

--- a/src/scripts/towns/BattleCafe.ts
+++ b/src/scripts/towns/BattleCafe.ts
@@ -115,7 +115,7 @@ class BattleCafeController {
     public static rechargeSpin(hour: number): void {
         if ((hour % BattleCafeController.period) == 0) {
             const recharge = BattleCafeController.spinsLeft() + BattleCafeController.defaultRecharge;
-            BattleCafeController.spinsLeft(Math.min(BattleCafeController.baseMaxSpins, recharge));
+            BattleCafeController.spinsLeft(Math.min(BattleCafeController.spinsPerDay(), recharge));
         }
     }
 


### PR DESCRIPTION
*The recharge function didn't take into account the spinsPerDay variable that increases with each sweet. Hopefully this fixes that.

*Added daily spins refresh from the original repo since the recharge function only currently works when the game is not closed.