### PR TITLE
Egg cycles fix

### DIFF
--- a/src/modules/pokemons/PokemonList.ts
+++ b/src/modules/pokemons/PokemonList.ts
@@ -27017,7 +27017,13 @@ pokemonList.forEach((p) => {
         // Calculate evolutions egg steps to be higher than the base forms
         (p as PokemonListData).evolutions?.forEach((evo) => {
             const poke = pokemonList.find((_p) => _p.name === evo.evolvedPokemon);
-            poke.eggCycles = Math.min(maxEggCycles, Math.round(p.eggCycles * 1.5));
+            const basePoke = pokemonList.find((_p) => _p.id === Math.floor(poke.id));
+            if (Math.floor(p.id) != Math.floor(poke.id)) {
+                poke.eggCycles = Math.min(maxEggCycles, Math.round(p.eggCycles * 1.5));
+            }
+            else {
+                poke.eggCycles = basePoke.eggCycles;
+            }
         });
     }
     // Calculate this pokemons native region

--- a/src/modules/pokemons/PokemonList.ts
+++ b/src/modules/pokemons/PokemonList.ts
@@ -27018,10 +27018,9 @@ pokemonList.forEach((p) => {
         (p as PokemonListData).evolutions?.forEach((evo) => {
             const poke = pokemonList.find((_p) => _p.name === evo.evolvedPokemon);
             const basePoke = pokemonList.find((_p) => _p.id === Math.floor(poke.id));
-            if (Math.floor(p.id) != Math.floor(poke.id)) {
+            if (Math.floor(p.id) !== Math.floor(poke.id)) {
                 poke.eggCycles = Math.min(maxEggCycles, Math.round(p.eggCycles * 1.5));
-            }
-            else {
+            } else {
                 poke.eggCycles = basePoke.eggCycles;
             }
         });


### PR DESCRIPTION
Evolutions will use the 1.5x multiplier.
Alternate forms will use the base form egg cycles after multiplier.
Alternate forms still needs to be defined in the preevolution/another form, otherwise they will just use their predefined egg cycles.